### PR TITLE
Fix for clearColor

### DIFF
--- a/equirect-video-2.html
+++ b/equirect-video-2.html
@@ -459,6 +459,7 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
           let glayer = xrGLFactory.getSubImage(equirectlayer, frame);
 
           gl.disable(gl.SCISSOR_TEST);
+          gl.disable(gl.DEPTH_TEST);
           gl.viewport(glayer.viewport.x, glayer.viewport.y, glayer.viewport.width, glayer.viewport.height);
           gl.bindFramebuffer(gl.FRAMEBUFFER, fb);
           gl.framebufferTexture2D(gl.FRAMEBUFFER, gl.COLOR_ATTACHMENT0, gl.TEXTURE_2D, glayer.colorTexture, 0);
@@ -486,6 +487,7 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
             gl.framebufferTexture2D(gl.FRAMEBUFFER, gl.DEPTH_ATTACHMENT, gl.TEXTURE_2D, glLayer.depthStencilTexture, 0);
 
             gl.enable(gl.SCISSOR_TEST);
+            gl.enable(gl.DEPTH_TEST);
             gl.scissor(viewport.x, viewport.y, viewport.width, viewport.height);
             gl.clearColor(0.0, 0, 0, 0.0);
             gl.clear(gl.COLOR_BUFFER_BIT | gl.DEPTH_BUFFER_BIT);

--- a/equirect-video-2.html
+++ b/equirect-video-2.html
@@ -431,7 +431,7 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
       // disappear.
       if (pose) {
         let arraylength = session.renderState.layers.length;
-
+/*
         if (equirectlayerbackdrop && (!texture_copied || equirectlayerbackdrop.needsRedraw)) {
           texture_copied = true;
           let glayer = xrGLFactory.getSubImage(equirectlayerbackdrop, frame);
@@ -449,17 +449,19 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
           gl.bindFramebuffer(gl.FRAMEBUFFER, null);
           gl.deleteFramebuffer(xrReadFramebuffer);
         }
-
+*/
         if (updatevideo || update_every_frame.checked || equirectlayer.needsRedraw) {
           needsRedraw = false
           updatevideo = false;
 
           let fb = gl.createFramebuffer();
-          gl.viewport(0, 0, layerWidth, layerHeight);
 
           let glayer = xrGLFactory.getSubImage(equirectlayer, frame);
-          gl.framebufferTexture2D(gl.FRAMEBUFFER, gl.COLOR_ATTACHMENT0, gl.TEXTURE_2D, glayer.colorTexture, 0);
+
+          gl.disable(gl.SCISSOR_TEST);
+          gl.viewport(glayer.viewport.x, glayer.viewport.y, glayer.viewport.width, glayer.viewport.height);
           gl.bindFramebuffer(gl.FRAMEBUFFER, fb);
+          gl.framebufferTexture2D(gl.FRAMEBUFFER, gl.COLOR_ATTACHMENT0, gl.TEXTURE_2D, glayer.colorTexture, 0);
 
           drawQuad(gl);
 
@@ -485,6 +487,7 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
             gl.enable(gl.SCISSOR_TEST);
             gl.scissor(viewport.x, viewport.y, viewport.width, viewport.height);
+            gl.clearColor(0.0, 0, 0, 0.0);
             gl.clear(gl.COLOR_BUFFER_BIT | gl.DEPTH_BUFFER_BIT);
             gl.disable(gl.SCISSOR_TEST);
 

--- a/multi-layer-eqr180.html
+++ b/multi-layer-eqr180.html
@@ -566,6 +566,16 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
                 depth_rb : depth_rb } ;
       }
 
+      function doesRBExistForTheTexture(glLayer) {
+        for (let i = 0; i < renderbuffers.length; ++i) {
+          let rb = renderbuffers[i];
+          if (rb.colorTexture == glLayer.colorTexture) {
+            return true;
+          }
+        }
+        return false;  
+      }
+
       function onXRFrame(t, frame) {
         let session = frame.session;
         let refSpace = session.isImmersive ?
@@ -585,17 +595,11 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
           if (want_msaa && pose && renderbuffers.length == 0) {
             // setup renderbuffers
             let glLayer;
-            if (proj_layer.layout != "stereo") {
-              glLayer = xrGLFactory.getSubImage(proj_layer, frame);
+            for (let i = 0; i < pose.views.length; ++i) {
+              let view = pose.views[i];
+              glLayer = xrGLFactory.getViewSubImage(proj_layer, view);
 
-              let rb_desc = createRBForLayer(glLayer);
-              renderbuffers.push(rb_desc);
-            } else {
-              // multi texture
-              for (let i = 0; i < pose.views.length; ++i) {
-                let view = pose.views[i];
-                glLayer = xrGLFactory.getViewSubImage(proj_layer, view);
-
+              if (!doesRBExistForTheTexture(glLayer)) {
                 let rb_desc = createRBForLayer(glLayer);
                 renderbuffers.push(rb_desc);
               }
@@ -770,7 +774,6 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
         if (want_msaa && session.isImmersive) {
           gl.invalidateFramebuffer(gl.DRAW_FRAMEBUFFER, [gl.DEPTH_ATTACHMENT]);
-          gl.invalidateFramebuffer(gl.READ_FRAMEBUFFER, [gl.DEPTH_ATTACHMENT]);
           for (let i = 0; i < renderbuffers.length; ++i) {
             let rb = renderbuffers[i];
             let fb = framebuffers[i];


### PR DESCRIPTION
When you targeted the quad, you set the clearColor to red
Then when we set up the projection layer, we just cleared it with the current color. This causes the projection layer to fill with red so nothing else was visible anymore.